### PR TITLE
Injecting BastionVM/BastionService as module's input variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ bastion_image_id | If use_bastion_service is set to FALSE then you can define Ba
 bastion_shape | If use_bastion_service is set to FALSE then you can define Bastion VM shape.
 bastion_flex_shape_ocpus | If use_bastion_service is set to FALSE and bastion_shape is using Flex shapes then you can define Flex Shape OCPUs.
 bastion_flex_shape_memory | If use_bastion_service is set to FALSE and bastion_shape is using Flex shapes then you can define Flex Shape Memory (GB).
+inject_bastion_service_id | Instead of counting on module to create Bastion Service you can pass Bastion Service OCID as input (set value to TRUE).
+bastion_service_id | If inject_bastion_service_id is set to TRUE then you can pass here Bastion Service OCID as input.
+inject_bastion_server_public_ip  | Instead of counting on module to create Bastion VM you can pass Bastion Host Public IP Address as input (set value to TRUE).
+bastion_server_public_ip | If inject_bastion_server_public_ip is set to TRUE then you can pass here Bastion Host Public IP Address.
 use_shared_storage | If numberOfNodes set to 2 or more then you can use shared NFS on OCI FSS (value TRUE). If you want to replicate Magento by yourself (for example with rsync) then you can you can set the value to FALSE.
 magento_shared_working_dir | If numberOfNodes set to 2 or more then you can define shared mountpoint name.
 label_prefix | To create unique identifier for multiple clusters in a compartment.

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/LICENSE
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/LICENSE
@@ -1,0 +1,35 @@
+Copyright (c) 2022 Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/README.md
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/README.md
@@ -1,0 +1,19 @@
+## Create Magento multi-node + custom network & Bastion Host injected into module
+This is an example of how to use the oci-arch-magento module to deploy Magento HA (multi-node) with MDS and network cloud infrastructure elements + Bastion Host injected into the module.
+  
+### Using this example
+Update terraform.tfvars with the required information.
+
+### Deploy the Magento
+Initialize Terraform:
+```
+$ terraform init
+```
+View what Terraform plans do before actually doing it:
+```
+$ terraform plan
+```
+Use Terraform to Provision resources:
+```
+$ terraform apply
+```

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/bastion_compute.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/bastion_compute.tf
@@ -1,0 +1,33 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+resource "oci_core_instance" "bastion" {
+  availability_domain = local.availability_domain_name
+  compartment_id      = var.compartment_ocid
+  display_name        = "bastionvm"
+  shape               = var.bastion_shape
+
+  dynamic "shape_config" {
+    for_each = local.is_flexible_node_shape ? [1] : []
+    content {
+      memory_in_gbs = var.bastion_flex_shape_memory
+      ocpus         = var.bastion_flex_shape_ocpus
+    }
+  }
+
+  create_vnic_details {
+    subnet_id        = oci_core_subnet.bastion_subnet_public.id
+    assign_public_ip = true
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = data.oci_core_images.InstanceImageOCID2.images[0].id
+  }
+
+  metadata = {
+    ssh_authorized_keys = module.magento.generated_ssh_public_key
+  }
+
+}
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/datasources.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/datasources.tf
@@ -1,0 +1,47 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+data "oci_core_images" "InstanceImageOCID" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.node_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_core_images" "InstanceImageOCID2" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.bastion_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_mysql_mysql_configurations" "shape" {
+  compartment_id = var.compartment_ocid
+  type           = ["DEFAULT"]
+  shape_name     = var.mysql_shape
+}
+
+data "oci_identity_region_subscriptions" "home_region_subscriptions" {
+  tenancy_id = var.tenancy_ocid
+
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = var.tenancy_ocid
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/magento.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/magento.tf
@@ -1,0 +1,43 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+module "magento" {
+  source                          = "github.com/oracle-devrel/terraform-oci-arch-magento"
+  source                          = "../../"
+  tenancy_ocid                    = var.tenancy_ocid
+  vcn_id                          = oci_core_virtual_network.magento_mds_vcn.id
+  numberOfNodes                   = 2
+  availability_domain_name        = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ADs.availability_domains[0], "name") : var.availability_domain_name
+  compartment_ocid                = var.compartment_ocid
+  image_id                        = lookup(data.oci_core_images.InstanceImageOCID.images[0], "id")
+  shape                           = var.node_shape
+  label_prefix                    = var.label_prefix
+  ssh_authorized_keys             = var.ssh_public_key
+  mds_ip                          = module.mds-instance.mysql_db_system.ip_address
+  magento_subnet_id               = oci_core_subnet.magento_subnet.id
+  lb_subnet_id                    = oci_core_subnet.lb_subnet_public.id 
+  bastion_subnet_id               = oci_core_subnet.bastion_subnet_public.id 
+  fss_subnet_id                   = oci_core_subnet.fss_subnet_private.id 
+  admin_password                  = var.admin_password
+  admin_username                  = var.admin_username
+  magento_schema                  = var.magento_schema
+  magento_name                    = var.magento_name
+  magento_password                = var.magento_password
+  magento_admin_firstname         = var.magento_admin_firstname
+  magento_admin_lastname          = var.magento_admin_lastname
+  magento_admin_login             = var.magento_admin_login
+  magento_admin_password          = var.magento_admin_password
+  magento_admin_email             = var.magento_admin_email
+  display_name                    = var.magento_instance_name
+  flex_shape_ocpus                = var.node_flex_shape_ocpus
+  flex_shape_memory               = var.node_flex_shape_memory
+  lb_shape                        = var.lb_shape 
+  flex_lb_min_shape               = var.flex_lb_min_shape 
+  flex_lb_max_shape               = var.flex_lb_max_shape 
+  use_bastion_service             = false
+  inject_bastion_service_id       = false
+  inject_bastion_server_public_ip = true
+  bastion_server_public_ip        = oci_core_instance.bastion.public_ip
+  bastion_service_region          = var.region
+}
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/mds.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/mds.tf
@@ -1,0 +1,22 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+module "mds-instance" {
+    source = "github.com/oracle-devrel/terraform-oci-cloudbricks-mysql-database?ref=v1.0.4.1"
+    tenancy_ocid                                    = var.tenancy_ocid
+    region                                          = var.region
+    mysql_instance_compartment_ocid                 = var.compartment_ocid
+    mysql_network_compartment_ocid                  = var.compartment_ocid
+    subnet_id                                       = oci_core_subnet.mds_subnet_private.id
+    mysql_db_system_admin_username                  = var.admin_username
+    mysql_db_system_admin_password                  = var.admin_password
+    mysql_db_system_availability_domain             = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ADs.availability_domains[0], "name") : var.availability_domain_name
+    mysql_shape_name                                = var.mysql_shape
+    mysql_db_system_data_storage_size_in_gb         = var.mysql_db_system_data_storage_size_in_gb
+    mysql_db_system_description                     = var.mysql_db_system_description
+    mysql_db_system_display_name                    = var.mysql_db_system_display_name
+    mysql_db_system_fault_domain                    = var.mysql_db_system_fault_domain
+    mysql_db_system_hostname_label                  = var.mysql_db_system_hostname_label
+    mysql_db_system_is_highly_available             = var.mysql_is_highly_available
+    mysql_db_system_maintenance_window_start_time   = var.mysql_db_system_maintenance_window_start_time
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/network.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/network.tf
@@ -1,0 +1,219 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+resource "oci_core_virtual_network" "magento_mds_vcn" {
+  cidr_block     = var.vcn_cidr
+  compartment_id = var.compartment_ocid
+  display_name   = var.vcn
+  dns_label      = "mamdsvcn"
+}
+
+
+resource "oci_core_internet_gateway" "internet_gateway" {
+  compartment_id = var.compartment_ocid
+  display_name   = "internet_gateway"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+}
+
+
+resource "oci_core_nat_gateway" "nat_gateway" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "nat_gateway"
+}
+
+
+resource "oci_core_route_table" "public_route_table" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "RouteTableViaIGW"
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.internet_gateway.id
+  }
+}
+
+resource "oci_core_route_table" "private_route_table" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "RouteTableViaNATGW"
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.nat_gateway.id
+  }
+}
+
+resource "oci_core_security_list" "public_security_list_ssh" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Allow Public SSH Connections to WordPress"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "6"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 22
+      min = 22
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+}
+
+resource "oci_core_security_list" "public_security_list_http" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Allow HTTP(S) to magento"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "6"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 80
+      min = 80
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 443
+      min = 443
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+}
+
+resource "oci_core_security_list" "private_security_list" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Private"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+  ingress_security_rules {
+    protocol = "1"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 22
+      min = 22
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 3306
+      min = 3306
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 33061
+      min = 33060
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      min = 2048
+      max = 2050
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      source_port_range {
+        min = 2048
+        max = 2050
+      }
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      min = 111
+      max = 111
+    }
+  }
+}
+
+resource "oci_core_subnet" "magento_subnet" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 2)
+  display_name               = "magento_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id 
+  security_list_ids          = [oci_core_security_list.public_security_list_ssh.id, oci_core_security_list.public_security_list_http.id]
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = true 
+  dns_label                  = "magsub"
+}
+
+resource "oci_core_subnet" "lb_subnet_public" {
+  cidr_block        = cidrsubnet(var.vcn_cidr, 8, 0)
+  display_name      = "lb_public_subnet"
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id    = oci_core_route_table.public_route_table.id
+  security_list_ids = [oci_core_security_list.public_security_list_http.id]
+  dhcp_options_id   = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  dns_label         = "lbpub"
+}
+
+resource "oci_core_subnet" "bastion_subnet_public" {
+  cidr_block        = cidrsubnet(var.vcn_cidr, 8, 1)
+  display_name      = "bastion_public_subnet"
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id    = oci_core_route_table.public_route_table.id
+  security_list_ids = [oci_core_security_list.public_security_list_ssh.id]
+  dhcp_options_id   = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  dns_label         = "bastionpub"
+}
+
+resource "oci_core_subnet" "fss_subnet_private" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 4)
+  display_name               = "fss_private_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = "true"
+  dns_label                  = "fsspriv"
+}
+
+resource "oci_core_subnet" "mds_subnet_private" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 3)
+  display_name               = "mds_private_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id
+  security_list_ids          = [oci_core_security_list.private_security_list.id]
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = "true"
+  dns_label                  = "mdspriv"
+}
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/output.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/output.tf
@@ -1,0 +1,33 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+output "magento_home_URL" {
+  value = "http://${module.magento.public_ip[0]}/"
+}
+
+output "generated_ssh_private_key" {
+  value     = module.magento.generated_ssh_private_key
+  sensitive = true
+}
+
+output "generated_ssh_public_key" {
+  value     = module.magento.generated_ssh_public_key
+  sensitive = true
+}
+
+output "magento_name" {
+  value = var.magento_name
+}
+
+output "magento_password" {
+  value = var.magento_password
+}
+
+output "magento_database" {
+  value = var.magento_schema
+}
+
+output "mds_instance_ip" {
+  value = module.mds-instance.mysql_db_system.ip_address
+  sensitive = true
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/provider.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/provider.tf
@@ -1,0 +1,20 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  region           = var.region
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+}
+
+provider "oci" {
+  alias                = "homeregion"
+  tenancy_ocid         = var.tenancy_ocid
+  user_ocid            = var.user_ocid
+  fingerprint          = var.fingerprint 
+  private_key_path     = var.private_key_path
+  region               = data.oci_identity_region_subscriptions.home_region_subscriptions.region_subscriptions[0].region_name
+  disable_auto_retries = "true"
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/terraform.tfvars.example
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# Authentication
+tenancy_ocid         = "<tenancy_ocid>"
+user_ocid            = "<user_ocid>"
+fingerprint          = "<fingerprint>"
+private_key_path     = "<private_key_path>"
+
+# Region
+region = "<region>"
+
+# Compartment
+compartment_ocid = "<compartment_ocid>"
+
+# MySQL admin password
+admin_password = "<admin_password>"
+
+# magento password
+magento_password = "<magento_password>"
+
+# magento admin password
+magento_admin_password = "<magento_admin_password>"
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/variables.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-host/variables.tf
@@ -1,0 +1,220 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+
+variable "ssh_public_key" {
+  default = ""
+}
+
+variable "availability_domain_name" {
+  default = ""
+}
+
+variable "tenancy_ocid" {
+  description = "Tenancy's OCID"
+}
+
+variable "compartment_ocid" {
+  description = "Compartment's OCID where VCN will be created. "
+}
+
+variable "region" {
+  description = "OCI Region"
+}
+
+variable "vcn" {
+  description = "VCN Name"
+  default     = "magento_mds_vcn"
+}
+
+variable "vcn_cidr" {
+  description = "VCN's CIDR IP Block"
+  default     = "10.0.0.0/16"
+}
+
+variable "node_image_id" {
+  description = "The OCID of an image for a node instance to use. "
+  default     = ""
+}
+
+variable "node_shape" {
+description = "Instance shape to use for master instance. "
+ default     = "VM.Standard.E4.Flex"
+}
+
+variable "node_flex_shape_ocpus" {
+  description = "Flex Instance shape OCPUs"
+  default = 1
+}
+
+variable "node_flex_shape_memory" {
+  description = "Flex Instance shape Memory (GB)"
+  default = 6
+}
+
+variable "label_prefix" {
+  description = "To create unique identifier for multiple setup in a compartment."
+  default     = ""
+}
+
+variable "lb_shape" {
+  default = "flexible"
+}
+
+variable "flex_lb_min_shape" {
+  default = "10"
+}
+
+variable "flex_lb_max_shape" {
+  default = "100"
+}
+
+variable "use_bastion_service" {
+  default = false
+}
+
+variable "bastion_shape" {
+  default = "VM.Standard.E4.Flex"
+}
+
+variable "bastion_flex_shape_ocpus" {
+  default = 1
+}
+
+variable "bastion_flex_shape_memory" {
+  default = 1
+}
+
+variable "instance_os" {
+  description = "Operating system for compute instances"
+  default     = "Oracle Linux"
+}
+
+variable "linux_os_version" {
+  description = "Operating system version for all Linux instances"
+  default     = "8"
+}
+
+variable "admin_password" {
+  description = "Password for the admin user for MySQL Database Service"
+}
+
+variable "admin_username" {
+  description = "MySQL Database Service Username"
+  default = "admin"
+}
+
+variable "ssh_authorized_keys_path" {
+  description = "Public SSH keys path to be included in the ~/.ssh/authorized_keys file for the default user on the instance. DO NOT FILL WHEN USING REOSURCE MANAGER STACK!"
+  default     = ""
+}
+
+variable "ssh_private_key_path" {
+  description = "The private key path to access instance. DO NOT FILL WHEN USING RESOURCE MANAGER STACK!"
+  default     = ""
+}
+
+variable "mysql_shape" {
+    default = "MySQL.VM.Standard.E3.1.8GB"
+}
+
+variable "magento_name" {
+  description = "magento Database User Name."
+  default     = "magento"
+}
+
+variable "magento_password" {
+  description = "magento Database User Password."
+  default     = ""
+}
+
+variable "magento_schema" {
+  description = "magento MySQL Schema"
+  default     = "magento"
+}
+
+variable "mds_instance_name" {
+  description = "Name of the MDS instance"
+  default     = "magentoMDS"
+}
+
+variable "mysql_is_highly_available" {
+  default = false
+}
+
+variable "mysql_db_system_data_storage_size_in_gb" {
+  default = 50
+}
+
+variable "mysql_db_system_description" {
+  description = "MySQL DB System for magento-MDS"
+  default = "MySQL DB System for magento-MDS"
+}
+
+variable "mysql_db_system_display_name" {
+  description = "MySQL DB System display name"
+  default = "magentoMDS"
+}
+
+variable "mysql_db_system_fault_domain" {
+  description = "The fault domain on which to deploy the Read/Write endpoint. This defines the preferred primary instance."
+  default = "FAULT-DOMAIN-1"
+}                  
+
+variable "mysql_db_system_hostname_label" {
+  description = "The hostname for the primary endpoint of the DB System. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, dbsystem-1 in FQDN dbsystem-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123."
+  default = "magentoMDS"
+}
+   
+variable "mysql_db_system_maintenance_window_start_time" {
+  description = "The start of the 2 hour maintenance window. This string is of the format: {day-of-week} {time-of-day}. {day-of-week} is a case-insensitive string like mon, tue, etc. {time-of-day} is the Time portion of an RFC3339-formatted timestamp. Any second or sub-second time data will be truncated to zero."
+  default = "SUNDAY 14:30"
+}
+
+variable "magento_instance_name" {
+  description = "Name of the magento compute instance"
+  default     = "magentovm"
+}
+
+variable "use_shared_storage" {
+  description = "Decide if you want to use shared NFS on OCI FSS"
+  default     = true
+}
+
+variable "magento_admin_password" {
+  description = "Magento Admin Password"
+}
+
+variable "magento_admin_email" {
+  description = "Magento Admin Email"
+  default = "john.doe@example.com"
+}
+
+variable "magento_admin_firstname" {
+  description = "Magento Admin First Name"
+  default = "John"
+}
+
+variable "magento_admin_lastname" {
+  description = "Magento Admin Last Name"
+  default = "Doe"
+}
+
+variable "magento_admin_login" {
+  description = "Magento Admin Login"
+  default = "admin"
+}
+
+# Dictionary Locals
+locals {
+  compute_flexible_shapes = [
+    "VM.Standard.E3.Flex",
+    "VM.Standard.E4.Flex"
+  ]
+  is_flexible_node_shape = contains(local.compute_flexible_shapes, var.bastion_shape)
+  availability_domain_name  = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ADs.availability_domains[0], "name") : var.availability_domain_name
+  
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/LICENSE
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/LICENSE
@@ -1,0 +1,35 @@
+Copyright (c) 2022 Oracle and/or its affiliates.
+
+The Universal Permissive License (UPL), Version 1.0
+
+Subject to the condition set forth below, permission is hereby granted to any
+person obtaining a copy of this software, associated documentation and/or data
+(collectively the "Software"), free of charge and under any and all copyright
+rights in the Software, and any and all patent rights owned or freely
+licensable by each licensor hereunder covering either (i) the unmodified
+Software as contributed to or provided by such licensor, or (ii) the Larger
+Works (as defined below), to deal in both
+
+(a) the Software, and
+(b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+one is included with the Software (each a "Larger Work" to which the Software
+is contributed by such licensors),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make,
+use, sell, offer for sale, import, export, have made, and have sold the
+Software and the Larger Work(s), and to sublicense the foregoing rights on
+either these or other terms.
+
+This license is subject to the following condition:
+The above copyright notice and either this complete permission notice or at
+a minimum a reference to the UPL must be included in all copies or
+substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/README.md
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/README.md
@@ -1,0 +1,19 @@
+## Create Magento multi-node + custom network & Bastion Service injected into module
+This is an example of how to use the oci-arch-magento module to deploy Magento HA (multi-node) with MDS and network cloud infrastructure elements + Bastion Service injected into the module.
+  
+### Using this example
+Update terraform.tfvars with the required information.
+
+### Deploy the Magento
+Initialize Terraform:
+```
+$ terraform init
+```
+View what Terraform plans do before actually doing it:
+```
+$ terraform plan
+```
+Use Terraform to Provision resources:
+```
+$ terraform apply
+```

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/bastion_service.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/bastion_service.tf
@@ -1,0 +1,11 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+resource "oci_bastion_bastion" "bastion_service" {
+  bastion_type                 = "STANDARD"
+  compartment_id               = var.compartment_ocid
+  target_subnet_id             = oci_core_subnet.magento_subnet.id
+  client_cidr_block_allow_list = ["0.0.0.0/0"]
+  name                         = "BastionService4Magento"
+  max_session_ttl_in_seconds   = 10800
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/datasources.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/datasources.tf
@@ -1,0 +1,47 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+data "oci_core_images" "InstanceImageOCID" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.node_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_core_images" "InstanceImageOCID2" {
+  compartment_id           = var.compartment_ocid
+  operating_system         = var.instance_os
+  operating_system_version = var.linux_os_version
+  shape                    = var.bastion_shape
+
+  filter {
+    name   = "display_name"
+    values = ["^.*Oracle[^G]*$"]
+    regex  = true
+  }
+}
+
+data "oci_mysql_mysql_configurations" "shape" {
+  compartment_id = var.compartment_ocid
+  type           = ["DEFAULT"]
+  shape_name     = var.mysql_shape
+}
+
+data "oci_identity_region_subscriptions" "home_region_subscriptions" {
+  tenancy_id = var.tenancy_ocid
+
+  filter {
+    name   = "is_home_region"
+    values = [true]
+  }
+}
+
+data "oci_identity_availability_domains" "ADs" {
+  compartment_id = var.tenancy_ocid
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/magento.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/magento.tf
@@ -1,0 +1,41 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+module "magento" {
+  source                         = "github.com/oracle-devrel/terraform-oci-arch-magento"
+  tenancy_ocid                    = var.tenancy_ocid
+  vcn_id                          = oci_core_virtual_network.magento_mds_vcn.id
+  numberOfNodes                   = 2
+  availability_domain_name        = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ADs.availability_domains[0], "name") : var.availability_domain_name
+  compartment_ocid                = var.compartment_ocid
+  image_id                        = lookup(data.oci_core_images.InstanceImageOCID.images[0], "id")
+  shape                           = var.node_shape
+  label_prefix                    = var.label_prefix
+  ssh_authorized_keys             = var.ssh_public_key
+  mds_ip                          = module.mds-instance.mysql_db_system.ip_address
+  magento_subnet_id               = oci_core_subnet.magento_subnet.id
+  lb_subnet_id                    = oci_core_subnet.lb_subnet_public.id 
+  fss_subnet_id                   = oci_core_subnet.fss_subnet_private.id 
+  admin_password                  = var.admin_password
+  admin_username                  = var.admin_username
+  magento_schema                  = var.magento_schema
+  magento_name                    = var.magento_name
+  magento_password                = var.magento_password
+  magento_admin_firstname         = var.magento_admin_firstname
+  magento_admin_lastname          = var.magento_admin_lastname
+  magento_admin_login             = var.magento_admin_login
+  magento_admin_password          = var.magento_admin_password
+  magento_admin_email             = var.magento_admin_email
+  display_name                    = var.magento_instance_name
+  flex_shape_ocpus                = var.node_flex_shape_ocpus
+  flex_shape_memory               = var.node_flex_shape_memory
+  lb_shape                        = var.lb_shape 
+  flex_lb_min_shape               = var.flex_lb_min_shape 
+  flex_lb_max_shape               = var.flex_lb_max_shape 
+  inject_bastion_service_id       = true
+  use_bastion_service             = true
+  inject_bastion_server_public_ip = false
+  bastion_service_id              = oci_bastion_bastion.bastion_service.id
+  bastion_service_region          = var.region
+}
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/mds.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/mds.tf
@@ -1,0 +1,22 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+module "mds-instance" {
+    source = "github.com/oracle-devrel/terraform-oci-cloudbricks-mysql-database?ref=v1.0.4.1"
+    tenancy_ocid                                    = var.tenancy_ocid
+    region                                          = var.region
+    mysql_instance_compartment_ocid                 = var.compartment_ocid
+    mysql_network_compartment_ocid                  = var.compartment_ocid
+    subnet_id                                       = oci_core_subnet.mds_subnet_private.id
+    mysql_db_system_admin_username                  = var.admin_username
+    mysql_db_system_admin_password                  = var.admin_password
+    mysql_db_system_availability_domain             = var.availability_domain_name == "" ? lookup(data.oci_identity_availability_domains.ADs.availability_domains[0], "name") : var.availability_domain_name
+    mysql_shape_name                                = var.mysql_shape
+    mysql_db_system_data_storage_size_in_gb         = var.mysql_db_system_data_storage_size_in_gb
+    mysql_db_system_description                     = var.mysql_db_system_description
+    mysql_db_system_display_name                    = var.mysql_db_system_display_name
+    mysql_db_system_fault_domain                    = var.mysql_db_system_fault_domain
+    mysql_db_system_hostname_label                  = var.mysql_db_system_hostname_label
+    mysql_db_system_is_highly_available             = var.mysql_is_highly_available
+    mysql_db_system_maintenance_window_start_time   = var.mysql_db_system_maintenance_window_start_time
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/network.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/network.tf
@@ -1,0 +1,208 @@
+## Copyright (c) 2022, Oracle and/or its affiliates. 
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+resource "oci_core_virtual_network" "magento_mds_vcn" {
+  cidr_block     = var.vcn_cidr
+  compartment_id = var.compartment_ocid
+  display_name   = var.vcn
+  dns_label      = "mamdsvcn"
+}
+
+
+resource "oci_core_internet_gateway" "internet_gateway" {
+  compartment_id = var.compartment_ocid
+  display_name   = "internet_gateway"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+}
+
+
+resource "oci_core_nat_gateway" "nat_gateway" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "nat_gateway"
+}
+
+
+resource "oci_core_route_table" "public_route_table" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "RouteTableViaIGW"
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_internet_gateway.internet_gateway.id
+  }
+}
+
+resource "oci_core_route_table" "private_route_table" {
+  compartment_id = var.compartment_ocid
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  display_name   = "RouteTableViaNATGW"
+  route_rules {
+    destination       = "0.0.0.0/0"
+    destination_type  = "CIDR_BLOCK"
+    network_entity_id = oci_core_nat_gateway.nat_gateway.id
+  }
+}
+
+resource "oci_core_security_list" "public_security_list_ssh" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Allow Public SSH Connections to WordPress"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "6"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 22
+      min = 22
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+}
+
+resource "oci_core_security_list" "public_security_list_http" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Allow HTTP(S) to magento"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "6"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 80
+      min = 80
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 443
+      min = 443
+    }
+    protocol = "6"
+    source   = "0.0.0.0/0"
+  }
+}
+
+resource "oci_core_security_list" "private_security_list" {
+  compartment_id = var.compartment_ocid
+  display_name   = "Private"
+  vcn_id         = oci_core_virtual_network.magento_mds_vcn.id
+
+  egress_security_rules {
+    destination = "0.0.0.0/0"
+    protocol    = "all"
+  }
+  ingress_security_rules {
+    protocol = "1"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 22
+      min = 22
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 3306
+      min = 3306
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+  ingress_security_rules {
+    tcp_options {
+      max = 33061
+      min = 33060
+    }
+    protocol = "6"
+    source   = var.vcn_cidr
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      min = 2048
+      max = 2050
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      source_port_range {
+        min = 2048
+        max = 2050
+      }
+    }
+  }
+
+  ingress_security_rules {
+    protocol = "6"
+    source   = var.vcn_cidr
+
+    tcp_options {
+      min = 111
+      max = 111
+    }
+  }
+}
+
+resource "oci_core_subnet" "magento_subnet" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 1)
+  display_name               = "magento_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id 
+  security_list_ids          = [oci_core_security_list.public_security_list_ssh.id, oci_core_security_list.public_security_list_http.id]
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = true 
+  dns_label                  = "magsub"
+}
+
+resource "oci_core_subnet" "lb_subnet_public" {
+  cidr_block        = cidrsubnet(var.vcn_cidr, 8, 2)
+  display_name      = "lb_public_subnet"
+  compartment_id    = var.compartment_ocid
+  vcn_id            = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id    = oci_core_route_table.public_route_table.id
+  security_list_ids = [oci_core_security_list.public_security_list_http.id]
+  dhcp_options_id   = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  dns_label         = "lbpub"
+}
+
+resource "oci_core_subnet" "fss_subnet_private" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 3)
+  display_name               = "fss_private_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = "true"
+  dns_label                  = "fsspriv"
+}
+
+resource "oci_core_subnet" "mds_subnet_private" {
+  cidr_block                 = cidrsubnet(var.vcn_cidr, 8, 4)
+  display_name               = "mds_private_subnet"
+  compartment_id             = var.compartment_ocid
+  vcn_id                     = oci_core_virtual_network.magento_mds_vcn.id
+  route_table_id             = oci_core_route_table.private_route_table.id
+  security_list_ids          = [oci_core_security_list.private_security_list.id]
+  dhcp_options_id            = oci_core_virtual_network.magento_mds_vcn.default_dhcp_options_id
+  prohibit_public_ip_on_vnic = "true"
+  dns_label                  = "mdspriv"
+}
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/output.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/output.tf
@@ -1,0 +1,33 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+output "magento_home_URL" {
+  value = "http://${module.magento.public_ip[0]}/"
+}
+
+output "generated_ssh_private_key" {
+  value     = module.magento.generated_ssh_private_key
+  sensitive = true
+}
+
+output "generated_ssh_public_key" {
+  value     = module.magento.generated_ssh_public_key
+  sensitive = true
+}
+
+output "magento_name" {
+  value = var.magento_name
+}
+
+output "magento_password" {
+  value = var.magento_password
+}
+
+output "magento_database" {
+  value = var.magento_schema
+}
+
+output "mds_instance_ip" {
+  value = module.mds-instance.mysql_db_system.ip_address
+  sensitive = true
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/provider.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/provider.tf
@@ -1,0 +1,20 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  region           = var.region
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+}
+
+provider "oci" {
+  alias                = "homeregion"
+  tenancy_ocid         = var.tenancy_ocid
+  user_ocid            = var.user_ocid
+  fingerprint          = var.fingerprint 
+  private_key_path     = var.private_key_path
+  region               = data.oci_identity_region_subscriptions.home_region_subscriptions.region_subscriptions[0].region_name
+  disable_auto_retries = "true"
+}

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/terraform.tfvars.example
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# Authentication
+tenancy_ocid         = "<tenancy_ocid>"
+user_ocid            = "<user_ocid>"
+fingerprint          = "<fingerprint>"
+private_key_path     = "<private_key_path>"
+
+# Region
+region = "<region>"
+
+# Compartment
+compartment_ocid = "<compartment_ocid>"
+
+# MySQL admin password
+admin_password = "<admin_password>"
+
+# magento password
+magento_password = "<magento_password>"
+
+# magento admin password
+magento_admin_password = "<magento_admin_password>"
+

--- a/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/variables.tf
+++ b/examples/magento-ha-mds-use-existing-network-and-injected-bastion-service/variables.tf
@@ -1,0 +1,209 @@
+## Copyright (c) 2022 Oracle and/or its affiliates.
+## All rights reserved. The Universal Permissive License (UPL), Version 1.0 as shown at http://oss.oracle.com/licenses/upl
+
+variable "user_ocid" {}
+variable "fingerprint" {}
+variable "private_key_path" {}
+
+variable "ssh_public_key" {
+  default = ""
+}
+
+variable "availability_domain_name" {
+  default = ""
+}
+
+variable "tenancy_ocid" {
+  description = "Tenancy's OCID"
+}
+
+variable "compartment_ocid" {
+  description = "Compartment's OCID where VCN will be created. "
+}
+
+variable "region" {
+  description = "OCI Region"
+}
+
+variable "vcn" {
+  description = "VCN Name"
+  default     = "magento_mds_vcn"
+}
+
+variable "vcn_cidr" {
+  description = "VCN's CIDR IP Block"
+  default     = "10.0.0.0/16"
+}
+
+variable "node_image_id" {
+  description = "The OCID of an image for a node instance to use. "
+  default     = ""
+}
+
+variable "node_shape" {
+description = "Instance shape to use for master instance. "
+ default     = "VM.Standard.E4.Flex"
+}
+
+variable "node_flex_shape_ocpus" {
+  description = "Flex Instance shape OCPUs"
+  default = 1
+}
+
+variable "node_flex_shape_memory" {
+  description = "Flex Instance shape Memory (GB)"
+  default = 6
+}
+
+variable "label_prefix" {
+  description = "To create unique identifier for multiple setup in a compartment."
+  default     = ""
+}
+
+variable "lb_shape" {
+  default = "flexible"
+}
+
+variable "flex_lb_min_shape" {
+  default = "10"
+}
+
+variable "flex_lb_max_shape" {
+  default = "100"
+}
+
+variable "use_bastion_service" {
+  default = false
+}
+
+variable "bastion_shape" {
+  default = "VM.Standard.E4.Flex"
+}
+
+variable "bastion_flex_shape_ocpus" {
+  default = 1
+}
+
+variable "bastion_flex_shape_memory" {
+  default = 1
+}
+
+variable "instance_os" {
+  description = "Operating system for compute instances"
+  default     = "Oracle Linux"
+}
+
+variable "linux_os_version" {
+  description = "Operating system version for all Linux instances"
+  default     = "8"
+}
+
+variable "admin_password" {
+  description = "Password for the admin user for MySQL Database Service"
+}
+
+variable "admin_username" {
+  description = "MySQL Database Service Username"
+  default = "admin"
+}
+
+variable "ssh_authorized_keys_path" {
+  description = "Public SSH keys path to be included in the ~/.ssh/authorized_keys file for the default user on the instance. DO NOT FILL WHEN USING REOSURCE MANAGER STACK!"
+  default     = ""
+}
+
+variable "ssh_private_key_path" {
+  description = "The private key path to access instance. DO NOT FILL WHEN USING RESOURCE MANAGER STACK!"
+  default     = ""
+}
+
+variable "mysql_shape" {
+    default = "MySQL.VM.Standard.E3.1.8GB"
+}
+
+variable "magento_name" {
+  description = "magento Database User Name."
+  default     = "magento"
+}
+
+variable "magento_password" {
+  description = "magento Database User Password."
+  default     = ""
+}
+
+variable "magento_schema" {
+  description = "magento MySQL Schema"
+  default     = "magento"
+}
+
+variable "mds_instance_name" {
+  description = "Name of the MDS instance"
+  default     = "magentoMDS"
+}
+
+variable "mysql_is_highly_available" {
+  default = false
+}
+
+variable "mysql_db_system_data_storage_size_in_gb" {
+  default = 50
+}
+
+variable "mysql_db_system_description" {
+  description = "MySQL DB System for magento-MDS"
+  default = "MySQL DB System for magento-MDS"
+}
+
+variable "mysql_db_system_display_name" {
+  description = "MySQL DB System display name"
+  default = "magentoMDS"
+}
+
+variable "mysql_db_system_fault_domain" {
+  description = "The fault domain on which to deploy the Read/Write endpoint. This defines the preferred primary instance."
+  default = "FAULT-DOMAIN-1"
+}                  
+
+variable "mysql_db_system_hostname_label" {
+  description = "The hostname for the primary endpoint of the DB System. Used for DNS. The value is the hostname portion of the primary private IP's fully qualified domain name (FQDN) (for example, dbsystem-1 in FQDN dbsystem-1.subnet123.vcn1.oraclevcn.com). Must be unique across all VNICs in the subnet and comply with RFC 952 and RFC 1123."
+  default = "magentoMDS"
+}
+   
+variable "mysql_db_system_maintenance_window_start_time" {
+  description = "The start of the 2 hour maintenance window. This string is of the format: {day-of-week} {time-of-day}. {day-of-week} is a case-insensitive string like mon, tue, etc. {time-of-day} is the Time portion of an RFC3339-formatted timestamp. Any second or sub-second time data will be truncated to zero."
+  default = "SUNDAY 14:30"
+}
+
+variable "magento_instance_name" {
+  description = "Name of the magento compute instance"
+  default     = "magentovm"
+}
+
+variable "use_shared_storage" {
+  description = "Decide if you want to use shared NFS on OCI FSS"
+  default     = true
+}
+
+variable "magento_admin_password" {
+  description = "Magento Admin Password"
+}
+
+variable "magento_admin_email" {
+  description = "Magento Admin Email"
+  default = "john.doe@example.com"
+}
+
+variable "magento_admin_firstname" {
+  description = "Magento Admin First Name"
+  default = "John"
+}
+
+variable "magento_admin_lastname" {
+  description = "Magento Admin Last Name"
+  default = "Doe"
+}
+
+variable "magento_admin_login" {
+  description = "Magento Admin Login"
+  default = "admin"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,22 @@ variable "bastion_flex_shape_memory" {
   default = 1
 }
 
+variable "inject_bastion_service_id" {
+  default = false
+}
+
+variable "bastion_service_id" {
+  default = ""
+}
+
+variable "inject_bastion_server_public_ip" {
+  default = false
+}
+
+variable "bastion_server_public_ip" {
+  default = ""
+}
+
 variable "use_shared_storage" {
   description = "Decide if you want to use shared NFS on OCI FSS"
   default     = true


### PR DESCRIPTION
## What's changed
- Added support for BastionVM (`inject_bastion_server_public_ip`, `bastion_server_public_ip`) or BastionService (`inject_bastion_service_id`, `bastion_service_id`) created outside of the module and injected into the module as inputs.
- Refreshed examples subdirectory (now they include new bastion-related features described above).