### PR TITLE
Support for setting up Magento with Redis Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ magento_admin_password | Magento Admin Password.
 magento_admin_email | Magento Admin E-mail.
 admin_username | Admin User Name for MySQL Server.
 admin_password | Admin User Password for MySQL Server.
+use_redis_cache | Decide if you want to setup Redis Cache for Magento
+redis_ip_address | IP Address of Redis Server for Magento Cache.
+redis_port | Port of Redis Server for Magento Cache.
+redis_password | Password for Redis Server for Magento Cache.
+redis_database | Database in Redis Server for Magento Cache.
 mds_ip | Private IP of the MySQL Server.
 defined_tags | Defined tags to be added to compute instances.
 

--- a/main.tf
+++ b/main.tf
@@ -363,6 +363,11 @@ data "template_file" "install_magento" {
     magento_admin_firstname    = var.magento_admin_firstname
     magento_admin_lastname     = var.magento_admin_lastname
     magento_admin_email        = var.magento_admin_email
+    use_redis_cache            = var.use_redis_cache
+    redis_ip_address           = var.redis_ip_address
+    redis_port                 = var.redis_port
+    redis_password             = var.redis_password
+    redis_database             = var.redis_database
   }
 }
 

--- a/scripts/install_magento.sh
+++ b/scripts/install_magento.sh
@@ -2,6 +2,7 @@
 #set -x
 
 export use_shared_storage='${use_shared_storage}'
+export use_redis_cache='${use_redis_cache}'
 
 if [[ $use_shared_storage == "true" ]]; then
   echo "Mount NFS share: ${magento_shared_working_dir}"
@@ -69,6 +70,9 @@ if [[ $use_shared_storage == "true" ]]; then
   ${magento_shared_working_dir}/bin/magento config:set web/secure/base_url https://${public_ip}/
   ${magento_shared_working_dir}/bin/magento config:set web/secure/use_in_frontend 1
   ${magento_shared_working_dir}/bin/magento config:set web/secure/use_in_adminhtml 0
+  if [[ $use_redis_cache == "true" ]]; then
+      ${magento_shared_working_dir}/bin/magento config:set --page-cache=redis --page-cache-redis-server=${use_redis_cache} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
+  fi
   cp /home/opc/index.html ${magento_shared_working_dir}/index.html
   rm /home/opc/index.html
   chown apache:apache -R ${magento_shared_working_dir}
@@ -77,7 +81,10 @@ else
   /var/www/html/bin/magento config:set web/unsecure/base_url http://${public_ip}/
   /var/www/html/bin/magento config:set web/secure/base_url https://${public_ip}/
   /var/www/html/bin/magento config:set web/secure/use_in_frontend 1
-  /var/www/html/bin/magento config:set web/secure/use_in_adminhtml 0  
+  /var/www/html/bin/magento config:set web/secure/use_in_adminhtml 0 
+  if [[ $use_redis_cache == "true" ]]; then
+      /var/www/html/bin/magento config:set --page-cache=redis --page-cache-redis-server=${use_redis_cache} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
+  fi 
   chown apache:apache -R /var/www/html
 fi
 

--- a/scripts/install_magento.sh
+++ b/scripts/install_magento.sh
@@ -71,7 +71,7 @@ if [[ $use_shared_storage == "true" ]]; then
   ${magento_shared_working_dir}/bin/magento config:set web/secure/use_in_frontend 1
   ${magento_shared_working_dir}/bin/magento config:set web/secure/use_in_adminhtml 0
   if [[ $use_redis_cache == "true" ]]; then
-      ${magento_shared_working_dir}/bin/magento config:set --page-cache=redis --page-cache-redis-server=${use_redis_cache} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
+      ${magento_shared_working_dir}/bin/magento config:set --page-cache=redis --page-cache-redis-server=${redis_ip_address} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
   fi
   cp /home/opc/index.html ${magento_shared_working_dir}/index.html
   rm /home/opc/index.html
@@ -83,7 +83,7 @@ else
   /var/www/html/bin/magento config:set web/secure/use_in_frontend 1
   /var/www/html/bin/magento config:set web/secure/use_in_adminhtml 0 
   if [[ $use_redis_cache == "true" ]]; then
-      /var/www/html/bin/magento config:set --page-cache=redis --page-cache-redis-server=${use_redis_cache} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
+      /var/www/html/bin/magento config:set --page-cache=redis --page-cache-redis-server=${redis_ip_address} --page-cache-redis-db=${redis_database} --page-cache-redis-port=${redis_port} --page-cache-redis-password=${redis_password}
   fi 
   chown apache:apache -R /var/www/html
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -205,6 +205,26 @@ variable "numberOfNodes" {
     default = 1
 }
 
+variable "use_redis_cache" {
+    default = false
+}           
+
+variable "redis_ip_address" {
+    default = ""
+}           
+
+variable "redis_port" {
+    default = 6379
+}                 
+
+variable "redis_password" {
+    default = ""
+}
+
+variable "redis_database" {
+    default = 0
+}
+
 # Dictionary Locals
 locals {
   compute_flexible_shapes = [


### PR DESCRIPTION
## What's changed 
 - If you set `use_redis_cache` to **TRUE** then you can pass Redis-related variables (`redis_ip_address`, `redis_database`, `redis_port`, `redis_password`). It will setup Redis cache during Redis configuration.